### PR TITLE
Feature 15: Singleton Tiles

### DIFF
--- a/src/main/java/ch/awae/simtrack/controller/tools/BuildTool.java
+++ b/src/main/java/ch/awae/simtrack/controller/tools/BuildTool.java
@@ -170,11 +170,11 @@ public class BuildTool implements ITool {
 	private void place() {
 		IModel model = this.editor.getController().getModel();
 		if (model.getTileAt(this.pos) == null)
-			model.setTileAt(this.pos, this.t.cloneTile());
+			model.setTileAt(this.pos, TileValidator.intern(t));
 		else {
 			ITile oldTile = model.getTileAt(this.pos);
 			model.removeTileAt(this.pos);
-			model.setTileAt(this.pos, FusedTrackFactory.createFusedTrack(oldTile, this.t));
+			model.setTileAt(this.pos, TileValidator.intern(FusedTrackFactory.createFusedTrack(oldTile, this.t)));
 		}
 	}
 
@@ -195,7 +195,6 @@ public class BuildTool implements ITool {
 		}
 		if (!this.isBulldoze && !mouse.button3()) {
 			// PLACER
-			this.t = t.withPosition(this.pos);
 			this.isValid = canPlaceOn(this.pos, model, this.t);
 			if (this.isValid) {
 				if (mouse.button1() && mouse.position().y < port.getScreenDimensions().y) {

--- a/src/main/java/ch/awae/simtrack/controller/tools/BuildToolRenderer.java
+++ b/src/main/java/ch/awae/simtrack/controller/tools/BuildToolRenderer.java
@@ -22,7 +22,6 @@ import java.awt.Color;
 import java.awt.Graphics2D;
 import java.awt.Stroke;
 
-import ch.awae.simtrack.model.ITile;
 import ch.awae.simtrack.model.position.TileCoordinate;
 import ch.awae.simtrack.view.IRenderer;
 import ch.awae.simtrack.view.IView;
@@ -56,10 +55,10 @@ class BuildToolRenderer implements IRenderer {
 
 	@Override
 	public void render(Graphics2D g, IView view) {
+		TileCoordinate c = this.tool.getPosition();
+		if (c == null)
+			return;
 		if (this.tool.isBulldoze()) {
-			TileCoordinate c = this.tool.getPosition();
-			if (c == null)
-				return;
 			Graphics2D g2 = view.getViewPort().focusHex(c, g);
 			g2.setColor(this.tool.isValid() ? Color.RED : darkRed);
 			g2.setStroke(bullCursorStroke);
@@ -69,15 +68,10 @@ class BuildToolRenderer implements IRenderer {
 				g2.rotate(angle);
 			}
 		} else {
-			ITile t = this.tool.getTrack();
-			if (t.getPosition() == null)
-				return;
-			Graphics2D g2 = view.getViewPort().focusHex(t.getPosition(), g);
+			Graphics2D g2 = view.getViewPort().focusHex(c, g);
 			g2.setStroke(railStroke);
-			TrackRenderUtil.renderRails(g2,
-					this.tool.isValid() ? Color.LIGHT_GRAY : Color.RED,
-					this.tool.isValid() ? Color.GRAY : Color.RED,
-					t.getRailPaths());
+			TrackRenderUtil.renderRails(g2, this.tool.isValid() ? Color.LIGHT_GRAY : Color.RED,
+					this.tool.isValid() ? Color.GRAY : Color.RED, tool.getTrack().getRailPaths());
 		}
 	}
 }

--- a/src/main/java/ch/awae/simtrack/model/BasicTrackTile.java
+++ b/src/main/java/ch/awae/simtrack/model/BasicTrackTile.java
@@ -18,7 +18,6 @@
 package ch.awae.simtrack.model;
 
 import ch.awae.simtrack.model.position.Edge;
-import ch.awae.simtrack.model.position.TileCoordinate;
 
 /**
  * @author Andreas Wälchli
@@ -26,16 +25,6 @@ import ch.awae.simtrack.model.position.TileCoordinate;
  * @since SimTrack 0.2.2
  */
 public abstract class BasicTrackTile implements ITile {
-
-	private TileCoordinate position;
-
-	public BasicTrackTile(TileCoordinate position) {
-		this.position = position;
-	}
-
-	public TileCoordinate getPosition() {
-		return this.position;
-	}
 
 	@Override
 	public boolean isFixed() {

--- a/src/main/java/ch/awae/simtrack/model/BorderTrackTile.java
+++ b/src/main/java/ch/awae/simtrack/model/BorderTrackTile.java
@@ -18,7 +18,6 @@
 package ch.awae.simtrack.model;
 
 import ch.awae.simtrack.model.position.Edge;
-import ch.awae.simtrack.model.position.TileCoordinate;
 
 /**
  * Implementation for the border track pieces. They do not contain any paths.
@@ -32,8 +31,7 @@ class BorderTrackTile extends BasicTrackTile {
 	private Edge edge;
 	private boolean isOutput;
 
-	public BorderTrackTile(TileCoordinate position, Edge edge, boolean isOutput) {
-		super(position);
+	public BorderTrackTile(Edge edge, boolean isOutput) {
 		this.edge = edge;
 		this.isOutput = isOutput;
 	}

--- a/src/main/java/ch/awae/simtrack/model/ConnectionSpawner.java
+++ b/src/main/java/ch/awae/simtrack/model/ConnectionSpawner.java
@@ -80,7 +80,7 @@ class ConnectionSpawner {
 
 			TileCoordinate pos = new TileCoordinate(u, v);
 			if (!list.contains(pos)) {
-				BorderTrackTile tile = new BorderTrackTile(pos, Edge.byIndex(edge), RAND.nextBoolean());
+				BorderTrackTile tile = new BorderTrackTile(Edge.byIndex(edge), RAND.nextBoolean());
 				model.setTileAt(pos, tile);
 				list.add(pos);
 			} else {

--- a/src/main/java/ch/awae/simtrack/model/IModel.java
+++ b/src/main/java/ch/awae/simtrack/model/IModel.java
@@ -17,7 +17,8 @@
  */
 package ch.awae.simtrack.model;
 
-import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import ch.awae.simtrack.model.position.TileCoordinate;
 
@@ -36,7 +37,7 @@ public interface IModel {
 
 	public void setTileAt(TileCoordinate position, ITile tile);
 
-	public List<ITile> getTiles();
+	public Set<Map.Entry<TileCoordinate, ITile>> getTiles();
 
 	public void removeTileAt(TileCoordinate position) throws IllegalArgumentException;
 

--- a/src/main/java/ch/awae/simtrack/model/ITile.java
+++ b/src/main/java/ch/awae/simtrack/model/ITile.java
@@ -18,7 +18,6 @@
 package ch.awae.simtrack.model;
 
 import ch.awae.simtrack.model.position.Edge;
-import ch.awae.simtrack.model.position.TileCoordinate;
 
 /**
  * @author Andreas Wälchli
@@ -26,8 +25,6 @@ import ch.awae.simtrack.model.position.TileCoordinate;
  * @since SimTrack 0.2.2 (0.2.1)
  */
 public interface ITile extends IEntity {
-
-	public TileCoordinate getPosition();
 
 	public boolean isFixed();
 

--- a/src/main/java/ch/awae/simtrack/model/ITransformableTile.java
+++ b/src/main/java/ch/awae/simtrack/model/ITransformableTile.java
@@ -1,7 +1,5 @@
 package ch.awae.simtrack.model;
 
-import ch.awae.simtrack.model.position.TileCoordinate;
-
 public interface ITransformableTile extends ITile {
 
 	public ITransformableTile cloneTile();
@@ -9,7 +7,5 @@ public interface ITransformableTile extends ITile {
 	public ITransformableTile rotated(boolean clockwise);
 
 	public ITransformableTile mirrored();
-
-	public ITransformableTile withPosition(TileCoordinate position);
 
 }

--- a/src/main/java/ch/awae/simtrack/model/Model.java
+++ b/src/main/java/ch/awae/simtrack/model/Model.java
@@ -17,9 +17,9 @@
  */
 package ch.awae.simtrack.model;
 
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import ch.awae.simtrack.model.position.TileCoordinate;
 
@@ -57,8 +57,8 @@ class Model implements IModel {
 	}
 
 	@Override
-	public List<ITile> getTiles() {
-		return new ArrayList<>(this.tiles.values());
+	public Set<Map.Entry<TileCoordinate, ITile>> getTiles() {
+		return tiles.entrySet();
 	}
 
 	@Override

--- a/src/main/java/ch/awae/simtrack/model/TileValidator.java
+++ b/src/main/java/ch/awae/simtrack/model/TileValidator.java
@@ -19,7 +19,9 @@ package ch.awae.simtrack.model;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import ch.awae.simtrack.model.track.TrackProvider;
 
@@ -33,9 +35,11 @@ import ch.awae.simtrack.model.track.TrackProvider;
 public class TileValidator {
 
 	private static List<TilePath[]> validTiles;
+	private static Map<Integer, ITile> tileCache;
 
 	static {
 		validTiles = new ArrayList<>();
+		tileCache = new HashMap<>();
 		for (int i = 0; i < TrackProvider.getTileCount(); i++) {
 			TilePath[] paths;
 			ITransformableTile t0 = TrackProvider.getTileInstance(i);
@@ -73,7 +77,7 @@ public class TileValidator {
 
 		// STEP 1: check for duplicates
 		for (int i = 0; i + 1 < paths.length; i += 2)
-			if (paths[i].equals(paths[i+1]))
+			if (paths[i].equals(paths[i + 1]))
 				return false;
 		// STEP 2: check for validity
 		for (TilePath[] sample : validTiles)
@@ -83,9 +87,26 @@ public class TileValidator {
 	}
 
 	public static void sortPathList(TilePath[] list) {
-		for (int i = 0; i < list.length; i ++)
+		for (int i = 0; i < list.length; i++)
 			list[i] = list[i].normalised();
 		Arrays.sort(list);
 		return;
+	}
+
+	/**
+	 * Caches the tile if it is the first of it's kind to be placed, returns the
+	 * cached version otherwise
+	 * 
+	 * @return
+	 */
+	public static ITile intern(ITile tile) {
+		Integer key = Integer.valueOf(Arrays.hashCode(tile.getRailPaths()));
+		ITile res = tileCache.get(key);
+		if (res == null) {
+			tileCache.put(key, tile);
+			System.out.println("added new tile to cache with hash: " + key);
+			res = tile;
+		}
+		return res;
 	}
 }

--- a/src/main/java/ch/awae/simtrack/model/track/AnonymousTrack.java
+++ b/src/main/java/ch/awae/simtrack/model/track/AnonymousTrack.java
@@ -19,7 +19,6 @@ package ch.awae.simtrack.model.track;
 
 import ch.awae.simtrack.model.BasicTrackTile;
 import ch.awae.simtrack.model.TilePath;
-import ch.awae.simtrack.model.position.TileCoordinate;
 
 /**
  * @author Andreas Wälchli
@@ -31,8 +30,7 @@ class AnonymousTrack extends BasicTrackTile {
 	private float cost;
 	private TilePath[] connections;
 
-	AnonymousTrack(TileCoordinate position, TilePath[] connections, float cost) {
-		super(position);
+	AnonymousTrack(TilePath[] connections, float cost) {
 		this.connections = connections.clone();
 		this.cost = cost;
 	}

--- a/src/main/java/ch/awae/simtrack/model/track/FusedTrackFactory.java
+++ b/src/main/java/ch/awae/simtrack/model/track/FusedTrackFactory.java
@@ -22,7 +22,6 @@ import java.util.ArrayList;
 import ch.awae.simtrack.model.ITile;
 import ch.awae.simtrack.model.TilePath;
 import ch.awae.simtrack.model.TileValidator;
-import ch.awae.simtrack.model.position.TileCoordinate;
 
 /**
  * @author Andreas Wälchli
@@ -31,12 +30,12 @@ import ch.awae.simtrack.model.position.TileCoordinate;
  */
 public class FusedTrackFactory {
 
-	public static ITile createAnonymousTrack(TileCoordinate position, TilePath[] connections, float cost) {
-		return new AnonymousTrack(position, connections.clone(), cost);
+	public static ITile createAnonymousTrack(TilePath[] connections, float cost) {
+		return new AnonymousTrack(connections.clone(), cost);
 	}
 
 	public static ITile createAnonymousTrack(ITile tile) {
-		return new AnonymousTrack(tile.getPosition(), tile.getRailPaths().clone(), tile.getTravelCost());
+		return new AnonymousTrack(tile.getRailPaths().clone(), tile.getTravelCost());
 	}
 
 	public static ITile createFusedTrack(ITile tile0, ITile tile1) {
@@ -50,7 +49,7 @@ public class FusedTrackFactory {
 
 		cons = clean(cons);
 
-		return new AnonymousTrack(tile0.getPosition(), cons, Math.max(tile0.getTravelCost(), tile1.getTravelCost()));
+		return new AnonymousTrack(cons, Math.max(tile0.getTravelCost(), tile1.getTravelCost()));
 	}
 
 	private static TilePath[] clean(TilePath[] cons) {

--- a/src/main/java/ch/awae/simtrack/model/track/MutableTrack.java
+++ b/src/main/java/ch/awae/simtrack/model/track/MutableTrack.java
@@ -7,7 +7,6 @@ import ch.awae.simtrack.model.BasicTrackTile;
 import ch.awae.simtrack.model.ITransformableTile;
 import ch.awae.simtrack.model.TilePath;
 import ch.awae.simtrack.model.position.Edge;
-import ch.awae.simtrack.model.position.TileCoordinate;
 
 /**
  * mutable track implementation. used by the editor
@@ -22,8 +21,7 @@ class MutableTrack extends BasicTrackTile implements ITransformableTile {
 	private TilePath[] links;
 	private boolean specialMirror = false;
 
-	MutableTrack(TileCoordinate position, JsonObject json) {
-		super(position);
+	MutableTrack(JsonObject json) {
 		JsonArray a = json.getJsonArray("links");
 		this.links = new TilePath[a.size() / 2];
 		for (int i = 0; i + 1 < a.size(); i += 2) {
@@ -32,8 +30,7 @@ class MutableTrack extends BasicTrackTile implements ITransformableTile {
 		this.specialMirror = json.getBoolean("mirror", false);
 	}
 
-	private MutableTrack(TileCoordinate position, TilePath[] links, int rotation, boolean specialM) {
-		super(position);
+	private MutableTrack(TilePath[] links, int rotation, boolean specialM) {
 		this.links = links;
 		this.specialMirror = specialM;
 		this.rotation = rotation;
@@ -55,7 +52,7 @@ class MutableTrack extends BasicTrackTile implements ITransformableTile {
 		for (int i = 0; i < this.links.length; i++) {
 			links[i] = new TilePath(this.links[i]._1.getNeighbour(clockwise), this.links[i]._2.getNeighbour(clockwise));
 		}
-		return new MutableTrack(this.getPosition(), links, (rotation + (clockwise ? 1 : 5)) % 6, this.specialMirror);
+		return new MutableTrack(links, (rotation + (clockwise ? 1 : 5)) % 6, this.specialMirror);
 	}
 
 	@Override
@@ -72,7 +69,7 @@ class MutableTrack extends BasicTrackTile implements ITransformableTile {
 			for (int i = 0; i < tile.getRailPaths().length; i++)
 				links[i] = new TilePath(Edge.byIndex((6 - tile.getRailPaths()[i]._1.ordinal()) % 6),
 						Edge.byIndex((6 - tile.getRailPaths()[i]._2.ordinal()) % 6));
-			tile = new MutableTrack(this.getPosition(), links, 0, this.specialMirror);
+			tile = new MutableTrack(links, 0, this.specialMirror);
 			for (int i = 0; i < rot; i++)
 				tile = tile.rotated(true);
 			return tile;
@@ -81,12 +78,7 @@ class MutableTrack extends BasicTrackTile implements ITransformableTile {
 
 	@Override
 	public ITransformableTile cloneTile() {
-		return new MutableTrack(this.getPosition(), this.links.clone(), rotation, this.specialMirror);
-	}
-
-	@Override
-	public ITransformableTile withPosition(TileCoordinate position) {
-		return new MutableTrack(position, links, rotation, specialMirror);
+		return new MutableTrack(this.links.clone(), rotation, this.specialMirror);
 	}
 
 }

--- a/src/main/java/ch/awae/simtrack/model/track/TrackProvider.java
+++ b/src/main/java/ch/awae/simtrack/model/track/TrackProvider.java
@@ -22,7 +22,6 @@ import java.util.ArrayList;
 import javax.json.JsonObject;
 
 import ch.awae.simtrack.model.ITransformableTile;
-import ch.awae.simtrack.model.position.TileCoordinate;
 import ch.awae.simtrack.util.Resource;
 
 /**
@@ -40,7 +39,7 @@ public class TrackProvider {
 		JsonObject tracks = Resource.getJSON("tracks.json");
 
 		for (String key : tracks.keySet()) {
-			tiles.add(new MutableTrack(new TileCoordinate(0, 0), tracks.getJsonObject(key)));
+			tiles.add(new MutableTrack(tracks.getJsonObject(key)));
 		}
 	}
 

--- a/src/main/java/ch/awae/simtrack/view/TrackRenderer.java
+++ b/src/main/java/ch/awae/simtrack/view/TrackRenderer.java
@@ -21,8 +21,10 @@ import java.awt.BasicStroke;
 import java.awt.Color;
 import java.awt.Graphics2D;
 import java.awt.Stroke;
+import java.util.Map.Entry;
 
 import ch.awae.simtrack.model.ITile;
+import ch.awae.simtrack.model.position.TileCoordinate;
 
 /**
  * Renderer for track rendering
@@ -49,10 +51,12 @@ class TrackRenderer implements IRenderer {
 	public void render(Graphics2D g, IView view) {
 		g.setColor(bgColour);
 		IViewPort port = view.getViewPort();
-		for (ITile tile : view.getModel().getTiles()) {
-			if (!port.isVisible(tile.getPosition()))
+		for (Entry<TileCoordinate, ITile> pair : view.getModel().getTiles()) {
+			TileCoordinate pos = pair.getKey();
+			ITile tile = pair.getValue();
+			if (!port.isVisible(pos))
 				continue;
-			Graphics2D g2 = port.focusHex(tile.getPosition(), g);
+			Graphics2D g2 = port.focusHex(pos, g);
 			g2.fillPolygon(hexEdges[0], hexEdges[1], 6);
 			g2.setStroke(railStroke);
 			TrackRenderUtil.renderRails(g2, bedColour, railColour,


### PR DESCRIPTION
Current implementation is not truly singleton, but any tile that is placed is replaced by a cached version if one is known. sometimes composite tiles are not considered identical if created in different orders. But since there is a finite number of possible ways to construct the same tile the cache will remain finite and (on large maps) eventually be smaller than the number of placed tiles. (improves efficiency)

A future version may truly limit the number of tile instances and also treat visually identical tiles as the same object.